### PR TITLE
Point `node_modules/bs-platform` to `melange` to disguise `melange` as `bsb`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ _esy
 .merlin
 dune
 dune.bsb
+esy.lock
+.melange.eobjs

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@ _esy
 .merlin
 dune
 dune.bsb
-esy.lock
 .melange.eobjs

--- a/README.md
+++ b/README.md
@@ -20,10 +20,15 @@ Then:
 esy build
 ```
 
-to build the project. Now you should see a `_build` folder with all generated files, you can run
+to build the project. This command, as constructed in `esy.json`,
+
+1. generates a symbolically linked dir `bs-platform` in `node_modules`, which effectively makes `melange` the compiler behind the old `bsb` command, and then
+2. builds the project using the symbolically linked `bsb` command.
+
+Now you should see a `_build` folder with all generated files, you can run
 
 ```bash
 esy x node _build/default/src/Main.bs.js
 ```
 
-To see the result of the script running.
+to see the result of the script running.

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ esy build
 
 to build the project. This command, as constructed in `esy.json`,
 
-1. generates a symbolically linked dir `bs-platform` in `node_modules`, which effectively makes `melange` the compiler behind the old `bsb` command, and then
-2. builds the project using the symbolically linked `bsb` command.
+1. generates a symbolically linked dir `bs-platform` in `node_modules`, which is helpful when using JavaScript bundlers like Webpack that expect to find Melange stdlib JavaScript files under `node_modules/bs-platform`.
+2. builds the project.
 
 Now you should see a `_build` folder with all generated files, you can run
 

--- a/esy.json
+++ b/esy.json
@@ -7,7 +7,10 @@
   },
   "esy": {
     "buildsInSource": "unsafe",
-    "build": "bsb -make-world"
+    "build": [
+      "ln -sfn #{melange.install} node_modules/bs-platform",
+      "bsb -make-world"
+    ]
   },
   "installConfig": {
     "pnp": false


### PR DESCRIPTION
Would you be willing to merge this change? I would rather have this in the original template instead of maintaining a fork.