### PR TITLE
remove existing bs-platform

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -8,6 +8,7 @@
   "esy": {
     "buildsInSource": "unsafe",
     "build": [
+      "rm -rf node_modules/bs-platform",
       "ln -sfn #{melange.install} node_modules/bs-platform",
       "bsb -make-world"
     ]


### PR DESCRIPTION
If a dependency installs `bs-platform`, so the folder exists in `node_modules/bs-platform` the linking will not work.
`ln --force` removes existing files, but folders are not files so it doesn't do anything.

Not sure if it's a good idea to use it like this because it might be not what you expect that `esy` overwrites some node_modules folders