### PR TITLE
fix: Get ocaml-lsp-server working

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "ocaml.sandbox": {
+    "kind": "esy",
+    "root": "${workspaceFolder:melange-basic-template}"
+  }
+}

--- a/esy.json
+++ b/esy.json
@@ -2,8 +2,11 @@
   "name": "melange-project",
   "dependencies": {
     "ocaml": "4.12.x",
-    "melange": "melange-re/melange",
-    "@opam/ocaml-lsp-server": "*"
+    "melange": "melange-re/melange"
+  },
+  "devDependencies": {
+    "@opam/ocaml-lsp-server": "1.8.3",
+    "@opam/ocamlformat-rpc": "0.19.0"
   },
   "esy": {
     "buildsInSource": "unsafe",


### PR DESCRIPTION
This fixes ocaml-lsp-server & the OCaml Platform vscode plugin by pinning the dependencies to the version that supported `.merlin` files. In 1.9.0, they dropped support for merlin files and if any exist, it marks all of your code as an error.