### PR TITLE
fix: Ensure esy runs in the workspace directory

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "ocaml.sandbox": {
     "kind": "custom",
-    "template": "esy $prog $args --fallback-read-dot-merlin"
+    "template": "esy -P ${workspaceFolder:melange-basic-template} $prog $args --fallback-read-dot-merlin"
   }
 }


### PR DESCRIPTION
This uses the "variable expansion" feature of the ocaml-platform extension to ensure esy runs in the workspace folder. This avoids the need to start vscode using esy.

This isn't the best solution for this "template" repo, but there is an unreleased feature of the ocaml-platform extension that will allow us to specify `${firstWorkspaceFolder}` instead. See https://github.com/ocamllabs/vscode-ocaml-platform/pull/1004