### PR TITLE
rename to melange-esy-template

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "ocaml.sandbox": {
     "kind": "custom",
-    "template": "esy -P ${workspaceFolder:melange-basic-template} $prog $args --fallback-read-dot-merlin"
+    "template": "esy -P ${workspaceFolder:melange-esy-template} $prog $args --fallback-read-dot-merlin"
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-# melange-basic-template
+# melange-esy-template
 
-A simple project template using [Melange](https://github.com/melange-re/melange).
+A simple project template using [Melange](https://github.com/melange-re/melange)
+with [esy](https://esy.sh/).
+
+If you are looking for a template with opam, check [melange-opam-template](https://github.com/melange-re/melange-opam-template).
 
 ## Quick Start
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "melange-basic-template",
+  "name": "melange-esy-template",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
As there is now https://github.com/melange-re/melange-opam-template, this template name should change to avoid confusion.

The PR also links to the opam template in the readme.

@anmonteiro after merging, please rename repo as well as I don't have permissions. Then I can update repo url on melange ci.